### PR TITLE
Add 'files' type to SlateType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare module 'slate-react' {
     focus(): void
   }
 
-  type SlateType = 'fragment' | 'html' | 'node' | 'rich' | 'text'
+  type SlateType = 'fragment' | 'html' | 'node' | 'rich' | 'text' | 'files'
 
   export function findDOMNode(node: Slate.Node): Element
   export function findDOMRange(range: Slate.Range): Range


### PR DESCRIPTION
SlateType is missing the 'files' type.  This happens when drag/dropping a file from external to the browser.