### PR TITLE
Added definitions to renderNode and renderMark props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,17 +3,28 @@ declare module 'slate-react' {
   import * as Immutable from 'immutable'
   import { ReactNode } from 'react'
 
+    // Values prefixed with "data-..." (Used for spellchecking according to docs)
+  type RenderAttributes = { [key: string]: any }
+
   type RenderMarkProps = {
-    mark: { type: string }
+    attributes: RenderAttributes
     children: ReactNode
+    editor: Editor
+    mark: Slate.Mark
+    marks: Immutable.Set<Slate.Mark>
+    node: Slate.Node
+    offset: number
+    text: string
   }
 
   type RenderNodeProps = {
-    node: Slate.Block
+    attributes: RenderAttributes
     children: ReactNode
-    attributes: any
-    isSelected: boolean
     editor: Editor
+    isSelected: boolean
+    key: string
+    node: Slate.Block
+    parent: Slate.Node
   }
 
   interface Plugin {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "@types/slate": {
-      "version": "git+https://github.com/JanLoebel/types-slate.git#0a845d18bf12c2a150ee65fff71122d38fa9d341",
+      "version": "git+https://github.com/JanLoebel/types-slate.git#53ca998eaad4837364c5f2dea8ce7e61c63a02fa",
       "dev": true
     },
     "csstype": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     {
       "name": "Jan Löbel",
       "url": "https://github.com/JanLoebel"
+    },
+    {
+      "name": "Patrick Sachs",
+      "url": "https://github.com/PatrickSachs"
     }
   ],
   "main": "",


### PR DESCRIPTION
Typings for the arguments of the functions `renderNode()` and `renderMark()` which are passed as props to the `<Editor />`.

I also took the liberty to add myself as a contributor o: